### PR TITLE
refactor: move markdown application helper to a private post method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,11 +10,4 @@ module ApplicationHelper
       content_tag :div, capture(&block), class: 'form-group'
     end
   end
-
-  def markdown(text)
-    renderer = Redcarpet::Render::HTML.new
-    extensions = { fenced_code_blocks: true }
-    redcarpet = Redcarpet::Markdown.new(renderer, extensions)
-    (redcarpet.render text).html_safe
-  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,4 +9,21 @@ class Post < ActiveRecord::Base
   validates :body, length: { minimum: 20 }, presence: true
   validates :topic, presence: true
   validates :user, presence: true
+
+  def markdown_title
+    render_as_markdown title
+  end
+
+  def markdown_body
+    render_as_markdown body
+  end
+
+  private
+
+  def render_as_markdown(text)
+    renderer = Redcarpet::Render::HTML.new
+    extensions = { fenced_code_blocks: true }
+    redcarpet = Redcarpet::Markdown.new(renderer, extensions)
+    (redcarpet.render text).html_safe
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,8 +1,8 @@
-<h1><%= markdown @post.title %></h1>
+<h1><%= @post.markdown_title %></h1>
 
 <% if policy(@post).edit? %>
   <%= link_to "Edit", edit_topic_post_path(@topic, @post), class: 'btn btn-success' %>
 <% end %>
 
-<p><%= markdown @post.body %></p>
+<p><%= @post.markdown_body %></p>
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,7 +15,7 @@
     <% @posts.each do |post| %>
       <div class='media'>
         <div class='media-body'>
-          <h4 class='media-heading'><%= link_to (markdown post.title), [@topic, post] %></h4>
+          <h4 class='media-heading'><%= link_to post.markdown_title, [@topic, post] %></h4>
           <small>
             <%= pluralize(post.comments.count, 'comment') %> &nbsp;
             submitted <%= time_ago_in_words(post.created_at) %> ago by <%= post.user.name %>


### PR DESCRIPTION
Moved markdown rendering logic from a global application_helper to a private post method. Now, post titles and bodies can be used directly using `markdown_title` and `markdown_body` instead of having to be passed through a helper method.
